### PR TITLE
Backend auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # -- V4 --
 # 1st Docker build stage: build the project with Maven
-FROM maven:3.6.3-openjdk-11 as builder
+FROM maven:3.6.3-openjdk-11 AS builder
+
+RUN openssl genrsa -out private.pem 2048 \
+&& openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+
 WORKDIR /project
 COPY . /project/
 RUN mvn package -DskipTests -B

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # -- V4 --
 # 1st Docker build stage: build the project with Maven
 FROM maven:3.6.3-openjdk-11 AS builder
-
-RUN openssl genrsa -out private.pem 2048 \
-&& openssl rsa -in private.pem -outform PEM -pubout -out public.pem
-
 WORKDIR /project
 COPY . /project/
 RUN mvn package -DskipTests -B

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,18 +1,19 @@
 services:
   ex-dock:
+    network_mode: host
     build: .
     ports:
       - "8888:8888"
-  database:
-    image: postgres:14-alpine
-    ports:
-      - "8890:5432"
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_DB=ex-dock
-    volumes:
-      - ./database/ex-dock.sql:/docker-entrypoint-initdb.d/datadump.sql
+#  database:
+#    image: postgres:14-alpine
+#    ports:
+#      - "8890:5432"
+#    environment:
+#      - POSTGRES_USER=postgres
+#      - POSTGRES_PASSWORD=docker
+#      - POSTGRES_DB=ex-dock
+#    volumes:
+#      - ./database/ex-dock.sql:/docker-entrypoint-initdb.d/datadump.sql
   # This is only used for testing purposes
   testDatabase:
     image: postgres:14-alpine

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
   database:
     image: postgres:14-alpine
     ports:
-      - 8890:5432
+      - "8890:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=docker
@@ -17,7 +17,7 @@ services:
   testDatabase:
     image: postgres:14-alpine
     ports:
-      - 8890:5432
+      - "8890:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=docker

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,17 @@
       <version>3.1.8</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-auth-jwt</artifactId>
+      <version>4.5.11</version>
+    </dependency>
 
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-auth-common</artifactId>
+      <version>4.5.11</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/kotlin/com/ex_dock/ex_dock/MainVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/MainVerticle.kt
@@ -58,9 +58,10 @@ class MainVerticle : AbstractVerticle() {
     vertx
       .createHttpServer()
       .requestHandler(mainRouter)
-      .listen(props.getProperty("FRONTEND_PORT").toInt()) {http ->
+      .listen(props.getProperty("FRONTEND_PORT").toInt()) { http ->
         if (http.succeeded()) {
           println("HTTP server started on port ${props.getProperty("FRONTEND_PORT")}")
+          startPromise.complete()
         } else {
           println("Failed to start HTTP server: ${http.cause()}")
           startPromise.fail(http.cause())

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/BackendRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/BackendRouter.kt
@@ -3,9 +3,12 @@ package com.ex_dock.ex_dock.backend
 import com.ex_dock.ex_dock.backend.v1.router.enableBackendV1Router
 import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
+import io.vertx.ext.web.handler.CorsHandler
 
 fun Router.enableBackendRouter(vertx: Vertx) {
   val backendRouter: Router = Router.router(vertx)
+
+  backendRouter.route().handler(CorsHandler.create())
 
   backendRouter.get("/about").handler { ctx ->
     ctx.end("about page for the APIs")

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
@@ -24,7 +24,7 @@ fun Router.enableBackendV1Router(vertx: Vertx, absoluteMounting: Boolean = false
       .addPubSecKey(
         PubSecKeyOptions()
           .setAlgorithm("RS256")
-          .setBuffer(authProvider.publickKey)
+          .setBuffer(authProvider.publicKey)
       )
       .addPubSecKey(
         PubSecKeyOptions()

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
@@ -1,12 +1,66 @@
 package com.ex_dock.ex_dock.backend.v1.router
 
 import com.ex_dock.ex_dock.backend.apiMountingPath
+import com.ex_dock.ex_dock.backend.v1.router.auth.AuthProvider
+import com.ex_dock.ex_dock.frontend.auth.ExDockAuthHandler
 import io.vertx.core.Vertx
+import io.vertx.core.json.JsonObject
+import io.vertx.ext.auth.JWTOptions
+import io.vertx.ext.auth.PubSecKeyOptions
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials
+import io.vertx.ext.auth.jwt.JWTAuth
+import io.vertx.ext.auth.jwt.JWTAuthOptions
 import io.vertx.ext.web.Router
+import io.vertx.ext.web.handler.JWTAuthHandler
 
 
 fun Router.enableBackendV1Router(vertx: Vertx, absoluteMounting: Boolean = false) {
   val backendV1Router: Router = Router.router(vertx)
+  val authProvider = AuthProvider()
+  val exDockAuthHandler = ExDockAuthHandler(vertx)
+  val jwtAuth = JWTAuth.create(
+    vertx,
+    JWTAuthOptions()
+      .addPubSecKey(
+        PubSecKeyOptions()
+          .setAlgorithm("RS256")
+          .setBuffer(authProvider.publickKey)
+      )
+      .addPubSecKey(
+        PubSecKeyOptions()
+         .setAlgorithm("HS256")
+         .setBuffer(authProvider.privateKey)
+      )
+  )
+
+  backendV1Router["/token"].handler { ctx ->
+    val credentials = UsernamePasswordCredentials(
+      "test@test.com",
+      "123456"
+    )
+
+    exDockAuthHandler.authenticate(credentials) {
+      if (it.succeeded()) {
+        val user = it.result()
+        val token = jwtAuth.generateToken(
+          JsonObject().apply {
+            put("userId", user.principal().getString("userId"))
+            put("email", user.principal().getString("email"))
+          },
+          JWTOptions().apply {
+            algorithm = "HS256"
+            expiresInSeconds = 3600
+          }
+        )
+
+        ctx.response().putHeader("Content-Type", "text/plain").end(token)
+      } else {
+        ctx.response().setStatusCode(401).end("Authentication failed")
+      }
+    }
+  }
+
+  backendV1Router.route().handler(JWTAuthHandler.create(jwtAuth))
 
   // TODO: routing
 

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
@@ -11,6 +11,7 @@ import io.vertx.ext.auth.authentication.UsernamePasswordCredentials
 import io.vertx.ext.auth.jwt.JWTAuth
 import io.vertx.ext.auth.jwt.JWTAuthOptions
 import io.vertx.ext.web.Router
+import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.JWTAuthHandler
 
 
@@ -33,10 +34,13 @@ fun Router.enableBackendV1Router(vertx: Vertx, absoluteMounting: Boolean = false
       )
   )
 
-  backendV1Router["/token"].handler { ctx ->
+  backendV1Router.route().handler(BodyHandler.create())
+
+  backendV1Router.post("/token").handler { ctx ->
+    val requestBody = ctx.body().asJsonObject()
     val credentials = UsernamePasswordCredentials(
-      "test@test.com",
-      "123456"
+      requestBody.getString("email"),
+      requestBody.getString("password")
     )
 
     exDockAuthHandler.authenticate(credentials) {

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
@@ -7,14 +7,18 @@ import java.util.Base64
 class AuthProvider {
   private val generator: KeyPairGenerator = KeyPairGenerator.getInstance("RSA")
   private val keyPair: KeyPair = generator.generateKeyPair()
-  private val beginPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
-  private val endPrivateKey = "\n-----END PRIVATE KEY-----"
-  private val beginPublicKey = "-----BEGIN PUBLIC KEY-----\n"
-  private val endPublicKey = "\n-----END PUBLIC KEY-----"
-  val privateKey = beginPrivateKey +
+
+  private companion object {
+    const val BEGINPRIVATEKEY = "-----BEGIN PRIVATE KEY-----\n"
+    const val ENDPRIVATEKEY = "\n-----END PRIVATE KEY-----"
+    const val BEGINPUBLICKEY = "-----BEGIN PUBLIC KEY-----\n"
+    const val ENDPUBLICKEY = "\n-----END PUBLIC KEY-----"
+  }
+
+  val privateKey = BEGINPRIVATEKEY +
     Base64.getMimeEncoder().encodeToString(keyPair.private.encoded) +
-    endPrivateKey
-  val publicKey = beginPublicKey +
+    ENDPRIVATEKEY
+  val publicKey = BEGINPUBLICKEY +
     Base64.getMimeEncoder().encodeToString(keyPair.public.encoded) +
-    endPublicKey
+    ENDPUBLICKEY
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
@@ -1,12 +1,20 @@
 package com.ex_dock.ex_dock.backend.v1.router.auth
 
-import java.nio.charset.Charset
-import java.nio.file.Files
-import kotlin.io.path.Path
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.util.Base64
 
 class AuthProvider {
-  private val publicKeyFile = Path(System.getProperty("user.dir") + "\\public.pem")
-  private val privateKeyFile = Path(System.getProperty("user.dir") + "\\private.pem")
-  val publicKey = String(Files.readAllBytes(publicKeyFile), charset = Charset.defaultCharset())
-  val privateKey = String(Files.readAllBytes(privateKeyFile), charset = Charset.defaultCharset())
+  private val generator: KeyPairGenerator = KeyPairGenerator.getInstance("RSA")
+  private val keyPair: KeyPair = generator.generateKeyPair()
+  private val beginPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
+  private val endPrivateKey = "\n-----END PRIVATE KEY-----"
+  private val beginPublicKey = "-----BEGIN PUBLIC KEY-----\n"
+  private val endPublicKey = "\n-----END PUBLIC KEY-----"
+  val privateKey = beginPrivateKey +
+    Base64.getMimeEncoder().encodeToString(keyPair.private.encoded) +
+    endPrivateKey
+  val publicKey = beginPublicKey +
+    Base64.getMimeEncoder().encodeToString(keyPair.public.encoded) +
+    endPublicKey
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
@@ -1,45 +1,12 @@
 package com.ex_dock.ex_dock.backend.v1.router.auth
 
-class AuthProvider() {
+import java.nio.charset.Charset
+import java.nio.file.Files
+import kotlin.io.path.Path
 
-  val publickKey =
-    "-----BEGIN PUBLIC KEY-----\n" +
-      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgLy6sZ9SzmPEuBIuccLV\n" +
-      "FA3oSoZsGPGSYS7mVHd7olpUp5WODLFpeLFUMruL+de+NwgZnrDn+MaFiM86WLYn\n" +
-      "o6qFSS1ZYJ7dVJPtCKkQ/N4XKxPFZGpsZMyCdDKTRD8q7eEJCXLE5iGp61/6LKyf\n" +
-      "Ghlge/W+w4Z3k8OjfJYOLHabpB28GatkfmkxRXDzKCF3QnZXaNFOytZ2lJfC2Jc8\n" +
-      "oQUCoaxzGlVHiexfvutH6zmxCaJTmpbBJ3lNKqC25cj61NcojyyVUPSVeFKTN6z5\n" +
-      "EYEey1ssMuUJRb5VqjW9j/egT6vrgvllZ8fbVH6nAOF3uttbSDmcQJKN+9GqqHhJ\n" +
-      "jQIDAQAB\n" +
-      "-----END PUBLIC KEY-----"
-
-  val privateKey =
-    "-----BEGIN PRIVATE KEY-----\n" +
-      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCAvLqxn1LOY8S4\n" +
-      "Ei5xwtUUDehKhmwY8ZJhLuZUd3uiWlSnlY4MsWl4sVQyu4v51743CBmesOf4xoWI\n" +
-      "zzpYtiejqoVJLVlgnt1Uk+0IqRD83hcrE8VkamxkzIJ0MpNEPyrt4QkJcsTmIanr\n" +
-      "X/osrJ8aGWB79b7DhneTw6N8lg4sdpukHbwZq2R+aTFFcPMoIXdCdldo0U7K1naU\n" +
-      "l8LYlzyhBQKhrHMaVUeJ7F++60frObEJolOalsEneU0qoLblyPrU1yiPLJVQ9JV4\n" +
-      "UpM3rPkRgR7LWywy5QlFvlWqNb2P96BPq+uC+WVnx9tUfqcA4Xe621tIOZxAko37\n" +
-      "0aqoeEmNAgMBAAECggEAAiX5dkYIC2UDfxA2nDQPJZLcgdnfwJl6GDXAfD+ziCW6\n" +
-      "bJgvUwDm7K+w4wPZiyV8NCOQzI174Yfr6eOOFWA80HC5DAaTYOxlxH06IxSHMbZs\n" +
-      "a+NG6QJppVOlswC2ZRjUw5F80B6NMKChMEoIEmodtuweKGi/x+Lc6KdcJBPGUBxI\n" +
-      "ii0ii7xVQ9UGjWnJCHnqxrnpzr7cHKTemC9ac0fI2Uj+jG2grdQBbduyggidmhkr\n" +
-      "+CLfGB2A6t7WSTGPyUHSl4qy1LwUJCjxggsKHadKTDxedHZwqzSb2DxijM5eUwO6\n" +
-      "eos4xByn7sIofS+yLGSwexvrVVNjKMptxBfxr0ptNQKBgQC1Wg4H7LxkSC/4G24j\n" +
-      "s61PIjOIyRQ3hL1uzGmQwj6yU8upL2iNqjFIok1rhqjUQuiU43K0we4R1aBFk+4Y\n" +
-      "ja5Pc26roNSN3igakmJXtk6NRmm00TeNwM1YyACxvL6RuZ8yJnHwY4r5shvPbHXz\n" +
-      "9jpFdpmcgekDNkdWy+dVKxaHowKBgQC1umpbGeyA/g44M/9F1esp7RI6iMySv1pc\n" +
-      "CUP40xyCP680wPOBYZ+u4g0yFBrmf8v7xlSg4MomYFcA3xAE6VJ+HmULsYFpUF6y\n" +
-      "2GPUCb1PlMk6L+xEuMvWXqIR0fEYAd78ajahoMaoFP9RvHPmSHskRPGCj19jFVBQ\n" +
-      "HGYiLCG9DwKBgQCFYJ5BJdPIzW66QzJV/6fPM5BDYeAElRPdkWlyleoWrZpz6/Ix\n" +
-      "fqKQkQ3vrzIsKql0F3QdjSPS6hLeGVZbqJgyxur2P2sUi/di05aQe/x52veTjOwW\n" +
-      "zV45lZ8tGWvvMV3sPGpAKnXj/yKFA3gc3VMuE3QWr1T4j8sYAw84jGAdkQKBgGt4\n" +
-      "O892bEP4eqZIMc217WWU+rO9FOYv3ZsSK61qA7EPQmj7NsYr2ohMzKrx8tqfdx2F\n" +
-      "M6UUatf5H1q3j7yn0w4coXsh1TtXuTkg+SB7RgZbIgmUL7CQbJNw0X2iX2boLFuv\n" +
-      "4HEDKJhcGoXW4d+su44+a2jfqvRotV86/Dd3S9iHAoGAOBIIsp4Pe0ix7kKhuX8l\n" +
-      "KLtOXw1f6D9w7MLuBzkGm0mkCbqKd5GMMjrn6+HR8G0HtZDwrIfZFFxe3f+Fh/55\n" +
-      "+QWeSM/3dWXx7+aODCA9Y4cFvdngo9VxtKQa1h9LQHks1AFpJK26E+Pj09wxp9BQ\n" +
-      "Mmfwel+wdvOlcLmLzW9V6Ig=\n" +
-      "-----END PRIVATE KEY-----\n"
+class AuthProvider {
+  private val publicKeyFile = Path(System.getProperty("user.dir") + "\\public.pem")
+  private val privateKeyFile = Path(System.getProperty("user.dir") + "\\private.pem")
+  val publicKey = String(Files.readAllBytes(publicKeyFile), charset = Charset.defaultCharset())
+  val privateKey = String(Files.readAllBytes(privateKeyFile), charset = Charset.defaultCharset())
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
@@ -1,0 +1,45 @@
+package com.ex_dock.ex_dock.backend.v1.router.auth
+
+class AuthProvider() {
+
+  val publickKey =
+    "-----BEGIN PUBLIC KEY-----\n" +
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgLy6sZ9SzmPEuBIuccLV\n" +
+      "FA3oSoZsGPGSYS7mVHd7olpUp5WODLFpeLFUMruL+de+NwgZnrDn+MaFiM86WLYn\n" +
+      "o6qFSS1ZYJ7dVJPtCKkQ/N4XKxPFZGpsZMyCdDKTRD8q7eEJCXLE5iGp61/6LKyf\n" +
+      "Ghlge/W+w4Z3k8OjfJYOLHabpB28GatkfmkxRXDzKCF3QnZXaNFOytZ2lJfC2Jc8\n" +
+      "oQUCoaxzGlVHiexfvutH6zmxCaJTmpbBJ3lNKqC25cj61NcojyyVUPSVeFKTN6z5\n" +
+      "EYEey1ssMuUJRb5VqjW9j/egT6vrgvllZ8fbVH6nAOF3uttbSDmcQJKN+9GqqHhJ\n" +
+      "jQIDAQAB\n" +
+      "-----END PUBLIC KEY-----"
+
+  val privateKey =
+    "-----BEGIN PRIVATE KEY-----\n" +
+      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCAvLqxn1LOY8S4\n" +
+      "Ei5xwtUUDehKhmwY8ZJhLuZUd3uiWlSnlY4MsWl4sVQyu4v51743CBmesOf4xoWI\n" +
+      "zzpYtiejqoVJLVlgnt1Uk+0IqRD83hcrE8VkamxkzIJ0MpNEPyrt4QkJcsTmIanr\n" +
+      "X/osrJ8aGWB79b7DhneTw6N8lg4sdpukHbwZq2R+aTFFcPMoIXdCdldo0U7K1naU\n" +
+      "l8LYlzyhBQKhrHMaVUeJ7F++60frObEJolOalsEneU0qoLblyPrU1yiPLJVQ9JV4\n" +
+      "UpM3rPkRgR7LWywy5QlFvlWqNb2P96BPq+uC+WVnx9tUfqcA4Xe621tIOZxAko37\n" +
+      "0aqoeEmNAgMBAAECggEAAiX5dkYIC2UDfxA2nDQPJZLcgdnfwJl6GDXAfD+ziCW6\n" +
+      "bJgvUwDm7K+w4wPZiyV8NCOQzI174Yfr6eOOFWA80HC5DAaTYOxlxH06IxSHMbZs\n" +
+      "a+NG6QJppVOlswC2ZRjUw5F80B6NMKChMEoIEmodtuweKGi/x+Lc6KdcJBPGUBxI\n" +
+      "ii0ii7xVQ9UGjWnJCHnqxrnpzr7cHKTemC9ac0fI2Uj+jG2grdQBbduyggidmhkr\n" +
+      "+CLfGB2A6t7WSTGPyUHSl4qy1LwUJCjxggsKHadKTDxedHZwqzSb2DxijM5eUwO6\n" +
+      "eos4xByn7sIofS+yLGSwexvrVVNjKMptxBfxr0ptNQKBgQC1Wg4H7LxkSC/4G24j\n" +
+      "s61PIjOIyRQ3hL1uzGmQwj6yU8upL2iNqjFIok1rhqjUQuiU43K0we4R1aBFk+4Y\n" +
+      "ja5Pc26roNSN3igakmJXtk6NRmm00TeNwM1YyACxvL6RuZ8yJnHwY4r5shvPbHXz\n" +
+      "9jpFdpmcgekDNkdWy+dVKxaHowKBgQC1umpbGeyA/g44M/9F1esp7RI6iMySv1pc\n" +
+      "CUP40xyCP680wPOBYZ+u4g0yFBrmf8v7xlSg4MomYFcA3xAE6VJ+HmULsYFpUF6y\n" +
+      "2GPUCb1PlMk6L+xEuMvWXqIR0fEYAd78ajahoMaoFP9RvHPmSHskRPGCj19jFVBQ\n" +
+      "HGYiLCG9DwKBgQCFYJ5BJdPIzW66QzJV/6fPM5BDYeAElRPdkWlyleoWrZpz6/Ix\n" +
+      "fqKQkQ3vrzIsKql0F3QdjSPS6hLeGVZbqJgyxur2P2sUi/di05aQe/x52veTjOwW\n" +
+      "zV45lZ8tGWvvMV3sPGpAKnXj/yKFA3gc3VMuE3QWr1T4j8sYAw84jGAdkQKBgGt4\n" +
+      "O892bEP4eqZIMc217WWU+rO9FOYv3ZsSK61qA7EPQmj7NsYr2ohMzKrx8tqfdx2F\n" +
+      "M6UUatf5H1q3j7yn0w4coXsh1TtXuTkg+SB7RgZbIgmUL7CQbJNw0X2iX2boLFuv\n" +
+      "4HEDKJhcGoXW4d+su44+a2jfqvRotV86/Dd3S9iHAoGAOBIIsp4Pe0ix7kKhuX8l\n" +
+      "KLtOXw1f6D9w7MLuBzkGm0mkCbqKd5GMMjrn6+HR8G0HtZDwrIfZFFxe3f+Fh/55\n" +
+      "+QWeSM/3dWXx7+aODCA9Y4cFvdngo9VxtKQa1h9LQHks1AFpJK26E+Pj09wxp9BQ\n" +
+      "Mmfwel+wdvOlcLmLzW9V6Ig=\n" +
+      "-----END PRIVATE KEY-----\n"
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthProvider.kt
@@ -9,16 +9,16 @@ class AuthProvider {
   private val keyPair: KeyPair = generator.generateKeyPair()
 
   private companion object {
-    const val BEGINPRIVATEKEY = "-----BEGIN PRIVATE KEY-----\n"
-    const val ENDPRIVATEKEY = "\n-----END PRIVATE KEY-----"
-    const val BEGINPUBLICKEY = "-----BEGIN PUBLIC KEY-----\n"
-    const val ENDPUBLICKEY = "\n-----END PUBLIC KEY-----"
+    const val BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n"
+    const val END_PRIVATE_KEY = "\n-----END PRIVATE KEY-----"
+    const val BEGIN_PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----\n"
+    const val END_PUBLIC_KEY = "\n-----END PUBLIC KEY-----"
   }
 
-  val privateKey = BEGINPRIVATEKEY +
+  val privateKey = BEGIN_PRIVATE_KEY +
     Base64.getMimeEncoder().encodeToString(keyPair.private.encoded) +
-    ENDPRIVATEKEY
-  val publicKey = BEGINPUBLICKEY +
+    END_PRIVATE_KEY
+  val publicKey = BEGIN_PUBLIC_KEY +
     Base64.getMimeEncoder().encodeToString(keyPair.public.encoded) +
-    ENDPUBLICKEY
+    END_PUBLIC_KEY
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
@@ -4,6 +4,7 @@ import com.ex_dock.ex_dock.database.account.*
 import com.ex_dock.ex_dock.database.category.*
 import com.ex_dock.ex_dock.database.checkout.CheckoutJdbcVerticle
 import com.ex_dock.ex_dock.database.codec.GenericCodec
+import com.ex_dock.ex_dock.database.codec.GenericListCodec
 import com.ex_dock.ex_dock.database.home.HomeJdbcVerticle
 import com.ex_dock.ex_dock.database.product.*
 import com.ex_dock.ex_dock.database.scope.FullScope
@@ -180,6 +181,8 @@ class JDBCStarter : AbstractVerticle() {
       .registerCodec(GenericCodec(Template::class.java))
       .registerCodec(GenericCodec(Block::class.java))
       .registerCodec(GenericCodec(Map::class.java))
+
+      .registerCodec(GenericListCodec(FullUser::class))
   }
 
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
@@ -49,7 +49,11 @@ class JDBCStarter : AbstractVerticle() {
           throw PopulateException("Could not populate the database with standard data. Closing the server!")
         }.onSuccess {
           println("Database populated with standard Data")
-          starPromise.complete()
+          eventBus.request<String>("process.service.addAdminUser", "").onFailure {
+            throw PopulateException("Could not add admin user. Closing the server!")
+          }.onSuccess {
+            starPromise.complete()
+          }
         }
       }
       .onFailure { error ->

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
@@ -34,5 +34,14 @@ enum class Permission(name: String) {
     fun fromString(value: String): Permission {
       return values().find { it.name == value } ?: NONE
     }
+
+    fun toString(permission: Permission): String {
+      return when (permission) {
+        NONE -> "none"
+        READ -> "read"
+        WRITE -> "write"
+        READ_WRITE -> "read-write"
+      }
+    }
   }
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
@@ -36,12 +36,7 @@ enum class Permission(name: String) {
     }
 
     fun toString(permission: Permission): String {
-      return when (permission) {
-        NONE -> "none"
-        READ -> "read"
-        WRITE -> "write"
-        READ_WRITE -> "read-write"
-      }
+      return permission.name
     }
   }
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
@@ -32,12 +32,7 @@ enum class Permission(name: String) {
 
   companion object {
     fun fromString(value: String): Permission {
-      return when (value) {
-        "read" -> READ
-        "write" -> WRITE
-        "read-write" -> READ_WRITE
-        else -> NONE
-      }
+      return values().find { it.name == value.lowercase() } ?: NONE
     }
 
     fun toString(permission: Permission): String {

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountClasses.kt
@@ -32,7 +32,12 @@ enum class Permission(name: String) {
 
   companion object {
     fun fromString(value: String): Permission {
-      return values().find { it.name == value } ?: NONE
+      return when (value) {
+        "read" -> READ
+        "write" -> WRITE
+        "read-write" -> READ_WRITE
+        else -> NONE
+      }
     }
 
     fun toString(permission: Permission): String {

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/account/AccountJdbcVerticle.kt
@@ -351,7 +351,7 @@ class AccountJdbcVerticle: AbstractVerticle() {
       val query = "SELECT u.user_id, u.email, u.password, bp.user_permissions, bp.server_settings, " +
         "bp.template, bp.category_content, bp.category_products, bp.product_content, bp.product_price, " +
         "bp.product_warehouse, bp.text_pages, bp.\"API_KEY\" FROM users u " +
-        "LEFT JOIN backend_permissions bp ON u.user_id = bp.user_id WHERE u.email =?"
+        "JOIN backend_permissions bp ON u.user_id = bp.user_id WHERE u.email =?"
       val rowsFuture = client.preparedQuery(query).execute(Tuple.of(email))
 
       rowsFuture.onFailure { res ->

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -59,7 +59,7 @@ class ServiceVerticle: AbstractVerticle() {
       }
 
       rowsFuture.onSuccess { res ->
-        if (res.size() == 0) {
+        if (res.size() < 1) {
           message.reply("Admin already exists!")
           return@onSuccess
         }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -59,6 +59,10 @@ class ServiceVerticle: AbstractVerticle() {
       }
 
       rowsFuture.onSuccess { res ->
+        if (res.size() < 1) {
+          message.reply("Admin already exists!")
+          return@onSuccess
+        }
         val userId = res.value().property(JDBCPool.GENERATED_KEYS).getInteger(0)
         val permissionQuery = "INSERT INTO backend_permissions " +
           "(user_id, user_permissions, server_settings, template, category_content, category_products, " +

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -1,10 +1,13 @@
 package com.ex_dock.ex_dock.database.service
 
+import com.ex_dock.ex_dock.database.account.Permission
 import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.EventBus
+import io.vertx.jdbcclient.JDBCPool
 import io.vertx.sqlclient.Pool
 import io.vertx.sqlclient.Tuple
+import org.mindrot.jbcrypt.BCrypt
 
 class ServiceVerticle: AbstractVerticle() {
   private lateinit var client: Pool
@@ -15,6 +18,7 @@ class ServiceVerticle: AbstractVerticle() {
     eventBus = vertx.eventBus()
 
     populateTemplateTable()
+    addAdminUser()
   }
 
   private fun populateTemplateTable() {
@@ -37,5 +41,55 @@ class ServiceVerticle: AbstractVerticle() {
 
       message.reply("Completed populating templates")
     }
+  }
+
+  private fun addAdminUser() {
+    eventBus.consumer<Any?>("process.service.addAdminUser").handler { message ->
+      val query = "INSERT INTO users (email, password) SELECT ?,? WHERE" +
+        " NOT EXISTS (SELECT * FROM users WHERE email =?)"
+      val rowsFuture = client.preparedQuery(query).execute(Tuple.of(
+        "test@test.com",
+        hashPassword("123456"),
+        "test@test.com"
+      ))
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.fail(500, "Failed to execute query")
+      }
+
+      rowsFuture.onSuccess { res ->
+        val userId = res.value().property(JDBCPool.GENERATED_KEYS).getInteger(0)
+        val permissionQuery = "INSERT INTO backend_permissions " +
+          "(user_id, user_permissions, server_settings, template, category_content, category_products, " +
+          "product_content, product_price, product_warehouse, text_pages, \"API_KEY\") VALUES " +
+          "(?,?::b_permissions,?::b_permissions,?::b_permissions,?::b_permissions,?::b_permissions,?::b_permissions," +
+          "?::b_permissions,?::b_permissions,?::b_permissions,?)"
+        val permissionTuple = Tuple.of(
+          userId,
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          Permission.toString(Permission.READ_WRITE),
+          null
+        )
+
+        client.preparedQuery(permissionQuery).execute(permissionTuple).onFailure { failure ->
+          println("Failed to execute query: $failure")
+          message.fail(500, "Failed to execute query")
+        }.onSuccess {
+          message.reply("Completed adding admin user")
+        }
+      }
+    }
+  }
+
+  private fun hashPassword(password: String): String {
+    return BCrypt.hashpw(password, BCrypt.gensalt(12))
   }
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -59,7 +59,7 @@ class ServiceVerticle: AbstractVerticle() {
       }
 
       rowsFuture.onSuccess { res ->
-        if (res.size() < 1) {
+        if (res.size() == 0) {
           message.reply("Admin already exists!")
           return@onSuccess
         }

--- a/src/test/kotlin/com/ex_dock/ex_dock/TestMainVerticle.kt
+++ b/src/test/kotlin/com/ex_dock/ex_dock/TestMainVerticle.kt
@@ -12,7 +12,12 @@ class TestMainVerticle {
 
   @BeforeEach
   fun deploy_verticle(vertx: Vertx, testContext: VertxTestContext) {
-    vertx.deployVerticle(MainVerticle()).onComplete(testContext.succeeding<String> { _ -> testContext.completeNow() })
+    vertx.deployVerticle(MainVerticle()).onFailure {
+      testContext.failNow(it)
+    }.onSuccess {
+      println("MainVerticle deployed successfully")
+      testContext.completeNow()
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/ex_dock/ex_dock/database/account/AccountJdbcVerticleTest.kt
+++ b/src/test/kotlin/com/ex_dock/ex_dock/database/account/AccountJdbcVerticleTest.kt
@@ -59,18 +59,21 @@ class AccountJdbcVerticleTest {
   }
 
   @Test
-  fun getAllUsersEmpty(vertx: Vertx, testContext: VertxTestContext) {
+  fun getAllUsers(vertx: Vertx, testContext: VertxTestContext) {
     val request = eventBus.request<String>("process.account.getAllUsers", "")
 
     request.onFailure { testContext.failNow(it) }
     request.onComplete { msg ->
       if (msg.failed()) testContext.failNow(msg.result().toString())
       var body: List<User> = msg.result().body() as List<User>
-      if (body!= emptyList<User>()) testContext.failNow(
-        "result is not equal to emptyList<User>()\nmsg.result().toString(): ${msg.result().body()}\n" +
-            "msg.result()::class: ${msg.result()::class}\n" +
-            "msg.result().body()::class: ${msg.result().body()::class}\n" +
-            "body: $body\nbody::class: ${body::class}"
+      if (body[0].email != "test@test.com" || body[1].email != "test@example.com") testContext.failNow(
+        "users are not as expected.\n" +
+            "body[0]:\n" +
+            "- expected: \"test@test.com\"" +
+            "- actual: \"${body[0].email}\"" +
+            "body[1]:\n" +
+            "- expected: \"test@example.com\"" +
+            "- expected: \"${body[1].email}\""
       )
       testContext.completeNow()
     }

--- a/src/test/kotlin/com/ex_dock/ex_dock/database/account/AccountJdbcVerticleTest.kt
+++ b/src/test/kotlin/com/ex_dock/ex_dock/database/account/AccountJdbcVerticleTest.kt
@@ -82,7 +82,7 @@ class AccountJdbcVerticleTest {
   @Test
   fun testUserData(vertx: Vertx, testContext: VertxTestContext) {
     val processAccountCreateUserCheckpoint = testContext.checkpoint()
-    val processAccountGetAllUsersCheckpoint = testContext.checkpoint(2)
+    val processAccountGetAllUsersCheckpoint = testContext.checkpoint()
     val processAccountGetUserByIdCheckpoint = testContext.checkpoint(2)
     val processAccountUpdateUserCheckpoint = testContext.checkpoint()
     val processAccountDeleteUserCheckpoint = testContext.checkpoint()
@@ -124,14 +124,13 @@ class AccountJdbcVerticleTest {
 
         eventBus.request<List<User>>("process.account.getAllUsers", "").onFailure {
           testContext.failNow(it)
-        }.onComplete { getAllMsg ->
+        }.onSuccess { getAllMsg ->
           try {
-            assert(getAllMsg.succeeded())
-            assertNotEquals(emptyList<User>(), getAllMsg.result().body())
+            assertNotEquals(emptyList<User>(), getAllMsg.body())
             assertTrue(
               BCrypt.checkpw(
-                "password",
-                getAllMsg.result().body()[0].password
+                "123456",
+                getAllMsg.body()[0].password
               )
             )
           } catch (e: Exception) {
@@ -215,19 +214,6 @@ class AccountJdbcVerticleTest {
                   }
 
                   processAccountDeleteUserCheckpoint.flag()
-
-                  eventBus.request<MutableList<User>>("process.account.getAllUsers", "").onFailure {
-                    testContext.failNow(it)
-                  }.onComplete { emptyMsg ->
-                    try {
-                      assert(emptyMsg.succeeded())
-                      assertEquals(emptyMsg.result().body(), emptyList<User>().toMutableList())
-                    } catch (e: Exception) {
-                      testContext.failNow(e)
-                    }
-
-                    processAccountGetAllUsersCheckpoint.flag()
-                  }
                 }
               }
             }


### PR DESCRIPTION
# Backend authorization using JWT
Adds the backend authorization using JWT and the RS256 algorithm.
## Startup
Adds an admin user to the user list in the database so the user can login to the backend. This user can later be configured. The public and private keys used in the JWT token are made on startup of the server. This means that when the server gets restarted that all the existing tokens also get invalidated.
## JWT auth
Extra methods in the already existing ExDockAuthProvider class. This allows the user to access data that is locked behind special permissions. Only the login path is not protected by the authenticator the rest is. To get a jwt token to login the user needs to access the backend on the path /api/v1/token.
## Docker
Made it so the main docker runs as host. This means that the ports that are published on the server are also published on the system. This allows for more clarity and communication between dockers.