### PR TITLE
System page

### DIFF
--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/BackendV1Router.kt
@@ -5,6 +5,7 @@ import com.ex_dock.ex_dock.backend.v1.router.auth.AuthProvider
 import com.ex_dock.ex_dock.database.backend_block.FullBlockInfo
 import com.ex_dock.ex_dock.frontend.auth.ExDockAuthHandler
 import com.ex_dock.ex_dock.backend.v1.router.image.initImage
+import com.ex_dock.ex_dock.backend.v1.router.system.enableSystemRouter
 import com.ex_dock.ex_dock.helper.convertJsonElement
 import com.ex_dock.ex_dock.helper.findValueByFieldName
 import com.ex_dock.ex_dock.helper.sendError
@@ -113,6 +114,7 @@ fun Router.enableBackendV1Router(vertx: Vertx, absoluteMounting: Boolean = false
 
   // TODO: routing
   backendV1Router.initImage(vertx)
+  backendV1Router.enableSystemRouter(vertx)
 
   this.route(
     if (absoluteMounting) "$apiMountingPath/v1*" else "/v1*"

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/auth/AuthRouter.kt
@@ -57,6 +57,10 @@ fun Router.enableAuthRouter(vertx: Vertx, absoluteMounting: Boolean = false) {
       }
   }
 
+  authRouter["/ping"].handler { ctx ->
+    ctx.response().end("Server responded!")
+  }
+
   this.route(
     if (absoluteMounting) "$apiMountingPath/v1*" else "/v1*"
   ).subRouter(authRouter)

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
@@ -15,6 +15,14 @@ fun Router.enableSystemRouter(vertx: Vertx) {
     }
   }
 
+  systemRouter["/setSettings"].handler { ctx ->
+    eventBus.request<String>("process.system.setVariables", ctx.body().asJsonObject()).onFailure { error ->
+      ctx.response().setStatusCode(400).end(error.message)
+    }.onSuccess {
+      ctx.response().end()
+    }
+  }
+
 
   this.route("/system*").subRouter(systemRouter)
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
@@ -15,10 +15,6 @@ fun Router.enableSystemRouter(vertx: Vertx) {
     }
   }
 
-  systemRouter["/ping"].handler { ctx ->
-    ctx.response().end("Server responded!")
-  }
-
 
   this.route("/system*").subRouter(systemRouter)
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
@@ -1,0 +1,20 @@
+package com.ex_dock.ex_dock.backend.v1.router.system
+
+import io.vertx.core.Vertx
+import io.vertx.ext.web.Router
+
+fun Router.enableSystemRouter(vertx: Vertx) {
+  val systemRouter = Router.router(vertx)
+  val eventBus = vertx.eventBus()
+
+  systemRouter["/test"].handler { ctx ->
+    eventBus.request<String>("process.system.getVariables", "").onFailure { error ->
+      ctx.response().setStatusCode(400).end(error.message)
+    }.onSuccess { message ->
+      ctx.response().end(message.body())
+    }
+  }
+
+
+  this.route("/system*").subRouter(systemRouter)
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
@@ -15,8 +15,8 @@ fun Router.enableSystemRouter(vertx: Vertx) {
     }
   }
 
-  systemRouter["/setSettings"].handler { ctx ->
-    eventBus.request<String>("process.system.setVariables", ctx.body().asJsonObject()).onFailure { error ->
+  systemRouter.post("/setSettings").handler { ctx ->
+    eventBus.request<String>("process.system.saveVariables", ctx.body().asJsonObject()).onFailure { error ->
       ctx.response().setStatusCode(400).end(error.message)
     }.onSuccess {
       ctx.response().end()

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemRouter.kt
@@ -7,12 +7,16 @@ fun Router.enableSystemRouter(vertx: Vertx) {
   val systemRouter = Router.router(vertx)
   val eventBus = vertx.eventBus()
 
-  systemRouter["/test"].handler { ctx ->
+  systemRouter["/getSettings"].handler { ctx ->
     eventBus.request<String>("process.system.getVariables", "").onFailure { error ->
       ctx.response().setStatusCode(400).end(error.message)
     }.onSuccess { message ->
       ctx.response().end(message.body())
     }
+  }
+
+  systemRouter["/ping"].handler { ctx ->
+    ctx.response().end("Server responded!")
   }
 
 

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
@@ -55,7 +55,7 @@ private fun JsonArray.addSettingAttribute(id: String, name: String, type: String
   val setting = JsonObject()
     .put("attribute_id", id)
     .put("attribute_name", name.encode())
-    .put("attribute_type", type.toBackOfficeType())
+    .put("attribute_type", type.toBackOfficeType(id))
     .put("current_attribute_value", value)
   this.add(setting)
 }
@@ -82,7 +82,9 @@ private fun String.encode(): String {
   return result
 }
 
-private fun String.toBackOfficeType(): String {
+private fun String.toBackOfficeType(name: String): String {
+  if (name.contains("PASSWORD", ignoreCase = true)) return "password"
+
   return when (this) {
     "Int" -> "int"
     else -> "text"

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
@@ -64,16 +64,12 @@ class SystemVerticle: AbstractVerticle() {
           }
         }
 
-        val path = ClassLoaderDummy::class.java.classLoader.getResource("secret.properties")
-        if (path == null) {
-          logger.error { "Could not find secret.properties" }
-          message.fail(400, "Could not find secret.properties")
-        }
+        val path = ClassLoaderDummy::class.java.classLoader.getResource("secret.properties")?.toURI()
+        println(path)
 
-        if (path != null) {
-          File(path.toURI()).delete()
-          File(path.toURI()).writeText(props.generateFileString())
-        }
+        println(File(path).delete())
+
+        props.store(File(path).outputStream(), null)
 
         message.reply("Successfully saved settings")
       } catch (_: Exception) {
@@ -123,13 +119,4 @@ private fun String.toBackOfficeType(name: String): String {
     "Int" -> "int"
     else -> "text"
   }
-}
-
-private fun Properties.generateFileString(): String {
-  val builder = StringBuilder()
-  this.entries.forEach { entry ->
-    builder.append("${entry.key}=${entry.value}\n")
-  }
-
-  return builder.toString()
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
@@ -1,0 +1,90 @@
+package com.ex_dock.ex_dock.backend.v1.router.system
+
+import com.ex_dock.ex_dock.ClassLoaderDummy
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.eventbus.EventBus
+import io.vertx.core.eventbus.Message
+import io.vertx.core.json.JsonArray
+import io.vertx.core.json.JsonObject
+import java.util.Properties
+
+class SystemVerticle: AbstractVerticle() {
+  companion object {
+    val logger = KotlinLogging.logger {}
+  }
+
+  private lateinit var eventBus: EventBus
+
+  override fun start() {
+    eventBus = vertx.eventBus()
+
+    getSystemVariables()
+  }
+
+  private fun getSystemVariables() {
+    eventBus.consumer<Unit>("process.system.getVariables").handler { message ->
+      val jsonSettings = JsonObject()
+      val settingsMap = JsonArray()
+      lateinit var props: Properties
+      try {
+        props = ClassLoaderDummy::class.java.classLoader.getResourceAsStream("secret.properties").use {
+          Properties().apply { load(it) }
+        }
+
+        props.generateResponse(message, jsonSettings, settingsMap)
+      } catch (_: Exception) {
+        logger.warn { "Could not find custom settings using default settings" }
+        try {
+          props = ClassLoaderDummy::class.java.classLoader.getResourceAsStream("default.properties").use {
+            Properties().apply { load(it) }
+          }
+
+          props.generateResponse(message, jsonSettings, settingsMap)
+        } catch (_: Exception) {
+          logger.error { "Could not find default settings" }
+          message.fail(400, "Could not find settings")
+        }
+      }
+    }
+  }
+}
+
+
+private fun JsonArray.addSettingAttribute(id: String, name: String, type: String, value: Any) {
+  val setting = JsonObject()
+    .put("attribute_id", id)
+    .put("attribute_name", name.encode())
+    .put("attribute_type", type.toBackOfficeType())
+    .put("current_attribute_value", value)
+  this.add(setting)
+}
+
+private fun Properties.generateResponse(message: Message<Unit>, jsonSettings: JsonObject, settingsMap: JsonArray) {
+  this.entries.forEach { entry ->
+    val key = entry.key
+    val value = entry.value
+    settingsMap.addSettingAttribute(key.toString(), key.toString(), value::class.java.simpleName, value.toString())
+  }
+
+  jsonSettings
+    .put("block_type", "standard")
+    .put("attributes", settingsMap)
+
+  message.reply(JsonObject()
+    .put("Backend Settings", jsonSettings).encodePrettily())
+}
+
+private fun String.encode(): String {
+  var result = this.lowercase()
+  result = result.replace("_", " ")
+  result = result.replaceFirstChar { it.uppercase() }
+  return result
+}
+
+private fun String.toBackOfficeType(): String {
+  return when (this) {
+    "Int" -> "int"
+    else -> "text"
+  }
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
@@ -59,7 +59,9 @@ class SystemVerticle: AbstractVerticle() {
         }
 
         props.entries.forEach { mutableEntry ->
-          props.setProperty(mutableEntry.key.toString(), message.body().getValue("${mutableEntry.key}") as String)
+          if (message.body().containsKey(mutableEntry.key.toString())) {
+            props.setProperty(mutableEntry.key.toString(), message.body().getValue("${mutableEntry.key}") as String)
+          }
         }
 
         val path = ClassLoaderDummy::class.java.classLoader.getResource("secret.properties")

--- a/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/backend/v1/router/system/SystemVerticle.kt
@@ -69,7 +69,13 @@ class SystemVerticle: AbstractVerticle() {
           logger.error { "Could not find secret.properties" }
           message.fail(400, "Could not find secret.properties")
         }
-        message.reply("test")
+
+        if (path != null) {
+          File(path.toURI()).delete()
+          File(path.toURI()).writeText(props.generateFileString())
+        }
+
+        message.reply("Successfully saved settings")
       } catch (_: Exception) {
         logger.error { "Could not find settings" }
         message.fail(400, "Could not find settings")
@@ -117,4 +123,13 @@ private fun String.toBackOfficeType(name: String): String {
     "Int" -> "int"
     else -> "text"
   }
+}
+
+private fun Properties.generateFileString(): String {
+  val builder = StringBuilder()
+  this.entries.forEach { entry ->
+    builder.append("${entry.key}=${entry.value}\n")
+  }
+
+  return builder.toString()
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
@@ -1,9 +1,9 @@
 package com.ex_dock.ex_dock.database
 
+import com.ex_dock.ex_dock.backend.v1.router.system.SystemVerticle
 import com.ex_dock.ex_dock.database.account.*
 import com.ex_dock.ex_dock.database.backend_block.*
 import com.ex_dock.ex_dock.database.auth.AuthenticationVerticle
-import com.ex_dock.ex_dock.database.backend_block.*
 import com.ex_dock.ex_dock.database.category.*
 import com.ex_dock.ex_dock.database.checkout.CheckoutJdbcVerticle
 import com.ex_dock.ex_dock.database.home.HomeJdbcVerticle
@@ -106,6 +106,7 @@ class JDBCStarter : AbstractVerticle() {
     verticles.add(vertx.deployWorkerVerticleHelper(BackendBlockJdbcVerticle::class))
     verticles.add(vertx.deployWorkerVerticleHelper(ImageJdbcVerticle::class))
     verticles.add(vertx.deployWorkerVerticleHelper(AuthenticationVerticle::class))
+    verticles.add(vertx.deployWorkerVerticleHelper(SystemVerticle::class))
   }
 
   private fun getAllCodecClasses() {

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -353,7 +353,6 @@ class ServiceVerticle: AbstractVerticle() {
         contentBlockId = 5
         imageBlockId = 3
         priceBlockId = 6
-        println("Completed first step")
         val addAttributeBlockQuery = "INSERT INTO attribute_block (block_id, attribute_id) SELECT ?,? " +
           "WHERE NOT EXISTS (SELECT * FROM attribute_block WHERE block_id = ? AND attribute_id = ?)"
         val rowsFuture14 = client.preparedQuery(addAttributeBlockQuery).execute(
@@ -439,7 +438,6 @@ class ServiceVerticle: AbstractVerticle() {
           println("Failed to execute all queries: $it")
           message.fail(500, "Failed to execute all queries")
         }.onComplete {
-          println("Completed second step")
           message.reply("")
         }
       }


### PR DESCRIPTION
# Changelog
- added system router page
- added /getSettings endpoint to get the settings from the server
- added /setSettings endpoint to save the settings to the server
- added the /ping endpoint to the auth router to ping for the server health
- added new System verticle to handle system requests
- The System verticle can fetch and save server settings from the properties file
- Saving settings is only on runtime for now and not yet globally
- Added system verticle to the JDBC starter